### PR TITLE
Install LLVM-11 from 3rd party repo to assure version 11 is available even if it isn't in the user's distro.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -48,6 +48,7 @@ RUN wget https://github.com/devkitPro/pacman/releases/download/v1.0.2/devkitpro-
 RUN gdebi -n devkitpro-pacman.amd64.deb
 
 # dkp-pacman gba
+RUN ln -s /proc/self/mounts /etc/mtab
 RUN dkp-pacman -S gba-dev --noconfirm
 
 


### PR DESCRIPTION
Installing all of LLVM instead of just clang-format-11 is gonna be somewhat of a waste of resources, but it was the cleanest way to do it since upstream has a script to install the entire thing, but not one to just add the repo.