### PR TITLE
Install clang-format-11. Suppress some warnings by installing apt-utils. Force-create the symlink to hopefully work on all configurations.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,8 @@ USER root
 
 RUN dpkg --add-architecture i386
 
+RUN apt-get update && apt-get install -y --no-install-recommends apt-utils
+
 RUN apt-get update && apt-get install -y \
     binutils-mips-linux-gnu \
     build-essential \
@@ -31,6 +33,7 @@ RUN pip3 install ansiwrap attrs capstone colour cxxfilt colorama gitpython lark-
 RUN wget https://apt.llvm.org/llvm.sh
 RUN chmod +x llvm.sh
 RUN ./llvm.sh 11
+RUN apt-get update & apt-get install -y clang-format-11
 
 # ccache
 RUN cp /usr/bin/ccache /usr/local/bin/
@@ -48,7 +51,7 @@ RUN wget https://github.com/devkitPro/pacman/releases/download/v1.0.2/devkitpro-
 RUN gdebi -n devkitpro-pacman.amd64.deb
 
 # dkp-pacman gba
-RUN ln -s /proc/self/mounts /etc/mtab
+RUN ln -f -s /proc/self/mounts /etc/mtab
 RUN dkp-pacman -S gba-dev --noconfirm
 
 


### PR DESCRIPTION
Clang-format-11 is not a dependency of what  gets installed by llvm.sh, so I had to install it manually afterward. While I was doing that, I cleaned up two other things.