### PR TITLE
Add Docker CI

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -1,0 +1,42 @@
+name: Build and Push Docker Image
+on:
+  push:
+    branches: [ master ]
+    tags: [ '*.*.*' ]
+
+jobs:
+  public_docker_image:
+    name: Publish Docker image to Github Registry
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: ghcr.io/${{ github.repository }}
+
+      - name: Check out the repo
+        uses: actions/checkout@v2
+
+      - name: Log in to GitHub Docker Registry
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GHCR_PAT }}
+
+      - name: Build and push to Github registry (latest)
+        uses: docker/build-push-action@v2
+        with:
+          push: true
+          tags: ghcr.io/${{ github.repository }}:latest
+        if: ${{ ! startsWith(github.ref, 'refs/tags/') }}
+
+      - name: Build and push to Github registry (versioned)
+        uses: docker/build-push-action@v2
+        with:
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+        if: startsWith(github.ref, 'refs/tags/')


### PR DESCRIPTION
probably merge this after the previous PR (so we can update the README to say "use ghcr.io/blahblah".. Also I nede you to create a PAT and save it as a secret named `GHCR_PAT` :)