### PR TITLE
Add `rabbitizer` to python packages

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -52,7 +52,8 @@ RUN pip3 install --no-cache \
     python-Levenshtein \
     python-ranges \
     pyyaml \
-    spimdisasm \
+    rabbitizer>=1.0.0 \
+    spimdisasm>=1.3.0 \
     stringcase \
     toml \
     tqdm \


### PR DESCRIPTION
Required by https://github.com/zeldaret/mm/pull/918

`rabbitizer` already gets installed by default because of `spimdisasm`, this PR just ensures the current version is installed instead