### PR TITLE
Adds Clang 14 tools

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -59,7 +59,7 @@ RUN pip3 install --no-cache \
     tqdm \
     watchdog
 
-# llvm
+# llvm 11
 RUN wget https://apt.llvm.org/llvm.sh \
     && chmod +x llvm.sh \
     && ./llvm.sh 11 \
@@ -67,6 +67,15 @@ RUN wget https://apt.llvm.org/llvm.sh \
 RUN apt-get update && apt-get install -y \
     clang-format-11 \
     clang-tidy-11
+
+# llvm 14
+RUN wget https://apt.llvm.org/llvm.sh \
+    && chmod +x llvm.sh \
+    && ./llvm.sh 14 \
+    && rm ./llvm.sh
+RUN apt-get update && apt-get install -y \
+    clang-format-14 \
+    clang-tidy-14
 
 # ccache
 RUN cp /usr/bin/ccache /usr/local/bin/ \


### PR DESCRIPTION
New docker image now has `clang-format-14` instead of 11

```bash
~/decomp/tools/jenkins$ docker run -it decomp-jenkins:latest bash
jenkins@34272466e64c:~$ clang-format-11
bash: clang-format-11: command not found
jenkins@34272466e64c:~$ clang-format-14 --version
Debian clang-format version 14.0.6
jenkins@34272466e64c:~$ 
```

This will need coordination for if/when MM actually switches to using clang-14.