### PR TITLE
Add libxml2-dev to installed apt packages

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     gdebi \
     libcapstone-dev \
     libpng-dev \
+    libxml2-dev \
     libyaml-dev \
     ninja-build \
     pkg-config \


### PR DESCRIPTION
This package is needed for shiny new tooling for audio assets handling in OoT https://github.com/zeldaret/oot/pull/2032 and MM https://github.com/zeldaret/mm/pull/1672