### PR TITLE
Add oot rom ntsc-1.2-us.z64

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ Below are the supported ROMs and their filenames. They should be placed in your 
 
 | Game (version)   | Desired filename     | SHA1 Hash                                  |
 | ---------------- | -------------------- | ------------------------------------------ |
+| OOT N64 1.2 US   | ntsc-1.2-us.z64      | `41b3bdc48d98c48529219919015a1af22f5057c2` |
 | OOT GC JP        | oot-gc-jp.z64        | `0769c84615422d60f16925cd859593cdfa597f84` |
 | OOT GC JP MQ     | oot-gc-jp-mq.z64     | `dd14e143c4275861fe93ea79d0c02e36ae8c6c2f` |
 | OOT GC JP CE     | oot-gc-jp-ce.z64     | `2ce2d1a9f0534c9cd9fa04ea5317b80da21e5e73` |


### PR DESCRIPTION
```
sha1sum: 41b3bdc48d98c48529219919015a1af22f5057c2
md5sum: 57a9719ad547c516342e1a15d5c28c3d
sha256sum: 49acd3885f13b0730119b78fb970911cc8aba614fe383368015c21565983368d
```

If you have the japanese equivalent ntsc-1.2-jp.z64 , the rom is identical beside a single byte you can manually edit at 0x3E, change 'J' to 'E'
